### PR TITLE
fix: Fix default model to use for spacy

### DIFF
--- a/piicatcher_spacy/detectors/spacy.py
+++ b/piicatcher_spacy/detectors/spacy.py
@@ -24,7 +24,7 @@ class SpacyDetector(DatumDetector):
     }
     name = 'DatumSpacyDetector'
 
-    def __init__(self, model: str = "en_US_core_news_lg"):
+    def __init__(self, model: str = "en_core_web_md"):
         super(SpacyDetector, self).__init__()
 
         # Fixes a warning message from transformers that is pulled in via spacy


### PR DESCRIPTION
en_US_core_news_lg is no longer available. Use en_core_web_md as it has
good precision for the size of the model.

Fix #2